### PR TITLE
大文字タグを小文字に

### DIFF
--- a/MyPortfolio/index.html
+++ b/MyPortfolio/index.html
@@ -55,9 +55,9 @@
   <footer>
     <ul>
       <li>
-        <A href="mailto:imokenpi141@gmail.com" target="_blank">
+        <a href="mailto:imokenpi141@gmail.com" target="_blank">
           <img src="img/mail.png" width="20" height="20" alt="メール送信">
-        </A>
+        </a>
       </li>
       <li>
         <a href="https://dotinstall.com" target="_blank">


### PR DESCRIPTION
タグは原則として小文字です。
昔はどちらもで良かったのですが、今は小文字で統一することが推奨されています。

こちらもabout.htmlの方は自分で修正してみてください。